### PR TITLE
Change cryptography version to 36.0.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -156,7 +156,7 @@ python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "cryptography"
-version = "36.0.1"
+version = "36.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false


### PR DESCRIPTION
`poetry install` 중 wsl 환경에서 `ERROR: cryptography-36.0.1-cp36-abi3-manylinux_2_24_x86_64.whl is not a supported wheel on this platform.` 가 뜨길래 36.0.2로 버전을 바꾸었습니다.